### PR TITLE
add foundry formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ docs/
 
 # Dotenv file
 .env
-
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "solidity.formatter": "forge",
+  "editor.wordWrapColumn": 150,
+  "editor.wordWrap": "wordWrapColumn",
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,6 @@
+[fmt] # See https://book.getfoundry.sh/reference/config/formatter
+line_length = 150
+
 [profile.default]
 libs = ['lib']
 src = 'src'


### PR DESCRIPTION
Adding in vscode workspace config and foundry settings to enforce common style and not wrap lines too aggressively 